### PR TITLE
Fix: vercel api url with https

### DIFF
--- a/frontend/src/lib/axios-init.ts
+++ b/frontend/src/lib/axios-init.ts
@@ -3,6 +3,6 @@ import axios from "axios";
 export const API = axios.create({
   baseURL:
     process.env.NODE_ENV === "production"
-      ? "http://unitum.herokuapp.com/api/"
+      ? "https://unitum.herokuapp.com/api/"
       : "http://localhost:5000/api/"
 });


### PR DESCRIPTION
Use https to bypass mixed content error from vercel.